### PR TITLE
Add module export. (Fixes #14)

### DIFF
--- a/src/ringme.js
+++ b/src/ringme.js
@@ -104,7 +104,7 @@ var RingMe = new function() {
   }
 
   // https://gist.github.com/aaronk6/d801d750f14ac31845e8
-  // this function is not under Savoir-faire Linux inc. copyright and license negociation 
+  // this function is not under Savoir-faire Linux inc. copyright and license negociation
   // for this code is ongoing here: https://gist.github.com/aaronk6/d801d750f14ac31845e8#gistcomment-1982506
   var _launchUri = function(uri, successCallback, noHandlerCallback, unknownCallback) {
     var res, parent, popup, iframe, timer, timeout, blurHandler, timeoutHandler, browser;
@@ -210,3 +210,4 @@ var RingMe = new function() {
   }
 }
 
+module.exports = RingMe;


### PR DESCRIPTION
## Fixes #14 @ssirois 

### Changes proposed in this pull request:

* Add a `module.export` at the end of the file to export the primary function for use in an NPM package.

### Status

- [x] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Requires push access to the Ringme.js NPM account.

### Additional notes

none
