### PR TITLE
Fix/2/check uri scheme on click

### DIFF
--- a/src/ringme.js
+++ b/src/ringme.js
@@ -17,24 +17,37 @@
  * along with ringme.js.  If not, see <http://www.gnu.org/licenses/>.
  */
 var RingMe = new function() {
+  var RING_DOWNLOAD_URL = "https://ring.cx/download";
+
   var URI_SCHEME_STATE = {
     UNSUPPORTED : 0,
     SUPPORTED : 1,
     UNKNOWN : 2,
+    UNCHECKED : 3,
   };
 
   this.action = null;
   this.identifier = null;
   this.container = null;
   this.ringUriScheme = "ring:";
-  this.ringUriSchemeSupported = URI_SCHEME_STATE.UNKNOWN;
+  this.ringUriSchemeSupported = URI_SCHEME_STATE.UNCHECKED;
 
   this.setRingUriSchemeSupport = function(isSupported) {
     this.ringUriSchemeSupported = isSupported;
   }
 
+  this.isRingSchemeSupported = function() {
+    if (this.ringUriSchemeSupported === URI_SCHEME_STATE.UNCHECKED) {
+      _doCheckRingUriSchemeSupport(this);
+    }
+
+    if (this.ringUriSchemeSupported === URI_SCHEME_STATE.SUPPORTED)
+      return true;
+    else
+      return false;
+  }
+
   this.ui = function(UI) {
-    _checkRingUriSchemeSupport(this);
 
     if ((UI.action !== undefined) && (UI.action !== null)) {
       this.action = UI.action;
@@ -51,7 +64,7 @@ var RingMe = new function() {
       console.log('Received container ID <' + this.container + '> has not been found in your page.');
     }
     else {
-      var ringUI = _createRingUI();
+      var ringUI = _createRingUI.apply(this);
 
       container.appendChild(ringUI);
     }
@@ -60,41 +73,44 @@ var RingMe = new function() {
   var _createRingUI = function() {
     var ui;
 
-    if (this.ringUriSchemeSupported === URI_SCHEME_STATE.SUPPORTED) {
-      var nbsp = '\u00A0';
+    var nbsp = '\u00A0';
 
-      ui = _createAnchor(
-        'ring:' + this.identifier,
-        'Ring' + nbsp + 'Me'
-      );
-    }
-    else if (this.ringUriSchemeSupported === URI_SCHEME_STATE.UNSUPPORTED) {
-      ui = _createAnchor(
-        'https://ring.cx/download',
-        'Download and install Ring to "Ring Me"'
-      );
-    }
-    else {
-      ui = _createAnchor(
-        'https://ring.cx/download',
-        'We cannot be sure if you have Ring\'s latest version. You might want to download it.'
-      );
-    }
+    ui = _createAnchor.apply(this,
+      ['ring:' + this.identifier,
+      'Ring' + nbsp + 'Me']
+    );
 
     return ui;
   }
 
   var _createAnchor = function(href, label) {
     var anchor = document.createElement('a');
-    anchor.setAttribute('href', href);
+    anchor.setAttribute('href', encodeURI(href));
     anchor.className = 'btn btn--beta btn--icon sflicon-gauge ring--button btn--download';
+    var ringUIInstance = this;
+    anchor.addEventListener('click', (function (event) {
+      if (!ringUIInstance.isRingSchemeSupported()) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        var redirect = confirm(
+          "We cannot be sure if you have Ring's latest version.\n" +
+          "You might want to download it at " + RING_DOWNLOAD_URL + "\n\n" +
+          "Do you wish to be redirected to Ring's download page?"
+        );
+
+        if (redirect) {
+          window.location = encodeURI(RING_DOWNLOAD_URL);
+        }
+      }
+    }));
     anchorText = document.createTextNode(label);
     anchor.appendChild(anchorText);
 
     return anchor;
   }
 
-  var _checkRingUriSchemeSupport = function(context) {
+  var _doCheckRingUriSchemeSupport = function(context) {
     _launchUri(
       context.ringUriScheme,
       function() { context.setRingUriSchemeSupport.call(context, URI_SCHEME_STATE.SUPPORTED); },

--- a/src/ringme.js
+++ b/src/ringme.js
@@ -84,30 +84,40 @@ var RingMe = new function() {
   }
 
   var _createAnchor = function(href, label) {
+    var ringUIInstance = this;
+
     var anchor = document.createElement('a');
     anchor.setAttribute('href', encodeURI(href));
     anchor.className = 'btn btn--beta btn--icon sflicon-gauge ring--button btn--download';
-    var ringUIInstance = this;
-    anchor.addEventListener('click', (function (event) {
-      if (!ringUIInstance.isRingSchemeSupported()) {
-        event.preventDefault();
-        event.stopPropagation();
-
-        var redirect = confirm(
-          "We cannot be sure if you have Ring's latest version.\n" +
-          "You might want to download it at " + RING_DOWNLOAD_URL + "\n\n" +
-          "Do you wish to be redirected to Ring's download page?"
+    anchor.addEventListener('click', (
+      function (event) {
+        _ringMeClickEventHandler.apply(
+          ringUIInstance,
+          [event]
         );
-
-        if (redirect) {
-          window.location = encodeURI(RING_DOWNLOAD_URL);
-        }
       }
-    }));
+    ));
     anchorText = document.createTextNode(label);
     anchor.appendChild(anchorText);
 
     return anchor;
+  }
+
+  var _ringMeClickEventHandler = function (event) {
+    if (!this.isRingSchemeSupported()) {
+      event.preventDefault();
+      event.stopPropagation();
+
+      var redirect = confirm(
+        "We cannot be sure if you have Ring's latest version.\n" +
+        "You might want to download it at " + RING_DOWNLOAD_URL + "\n\n" +
+        "Do you wish to be redirected to Ring's download page?"
+      );
+
+      if (redirect) {
+        window.location = encodeURI(RING_DOWNLOAD_URL);
+      }
+    }
   }
 
   var _doCheckRingUriSchemeSupport = function(context) {


### PR DESCRIPTION
## Fixes #2 by @philippemouchel

### Changes proposed in this pull request:

* Don't check for ring scheme support at load time;
* Check for ring scheme support when button is clicked;
* When ring scheme is not supported: display a confirmation box asking if visitor wishes to be redirected to Ring's download page.

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

#### First test

1. Make sure your "test box" **does support** the ring scheme
2. Open the test page and realize that Ring client does not appear
3. Click the button
4. Realize that Ring client does appear

#### Second test

1. Make sure your "test box" **does not support** the ring scheme
2. Open the test page and realize that RingMe button is there
3. Click the button
4. Realize that a confirmation box appears and works as expected (redirects or not, depending on your answer)

### Additional notes

This is not fancy but makes the feature accessible and understandable _de facto_.

If this feature is accepted as a fix for #2 then we might want to open a new issue regarding the look&feel of this confirmation box and the way we could display the "not supported" message.