### PR TITLE
Fix class names used on button (img or text)

### DIFF
--- a/src/ringme.js
+++ b/src/ringme.js
@@ -99,7 +99,7 @@ var RingMe = new function() {
     var img = document.createElement('img');
     img.setAttribute('src', buttonImage.src);
     img.setAttribute('alt', buttonImage.alt);
-    img.className = 'ring--button--img';
+    img.className = 'btn--ring--img';
 
     return img;
   }
@@ -110,7 +110,7 @@ var RingMe = new function() {
     var anchor = document.createElement('a');
     var anchorURI = encodeURI(href);
     anchor.setAttribute('href', anchorURI);
-    anchor.className = this.buttonClass || 'btn btn--beta btn--icon sflicon-gauge ring--button btn--download';
+    anchor.className = this.buttonClass || 'btn btn--ringme';
     anchor.addEventListener('click', (
       function (event) {
         event.preventDefault();


### PR DESCRIPTION
## Fixes #4 

### Changes proposed in this pull request:

* Removed long list of unnecessary classes from button (text & image)

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

Lookup the rendered button and make sure only `btn btn-ring` classes are specified on the anchor and if your are looking at the image button, make sure only `btn--ring--img` appears on the image element.
