### PR TITLE
Fix Issue #18

### DIFF
--- a/src/ringme.js
+++ b/src/ringme.js
@@ -108,7 +108,7 @@ var RingMe = new function() {
     var ringUIInstance = this;
 
     var anchor = document.createElement('a');
-    const anchorURI = encodeURI(href);
+    var anchorURI = encodeURI(href);
     anchor.setAttribute('href', anchorURI);
     anchor.className = this.buttonClass || 'btn btn--beta btn--icon sflicon-gauge ring--button btn--download';
     anchor.addEventListener('click', (

--- a/src/ringme.js
+++ b/src/ringme.js
@@ -108,16 +108,22 @@ var RingMe = new function() {
     var ringUIInstance = this;
 
     var anchor = document.createElement('a');
-    anchor.setAttribute('href', encodeURI(href));
+    const anchorURI = encodeURI(href);
+    anchor.setAttribute('href', anchorURI);
     anchor.className = this.buttonClass || 'btn btn--beta btn--icon sflicon-gauge ring--button btn--download';
     anchor.addEventListener('click', (
       function (event) {
+        event.preventDefault();
+        event.stopPropagation();
+
         if (!ringUIInstance.isRingSchemeSupported()) {
           window.setTimeout(function() {
             _ringMeClickEventHandler.apply(
               ringUIInstance,
               [event]);
             }, 600);
+        } else {
+          window.location = anchorURI
         }
       }
     ));
@@ -126,11 +132,8 @@ var RingMe = new function() {
     return anchor;
   }
 
-  var _ringMeClickEventHandler = function (event) {
+  var _ringMeClickEventHandler = function () {
     if (!this.isRingSchemeSupported()) {
-      event.preventDefault();
-      event.stopPropagation();
-
       var redirect = confirm(
         "We cannot be sure if you have Ring's latest version.\n" +
         "You might want to download it at " + RING_DOWNLOAD_URL + "\n\n" +

--- a/src/ringme.js
+++ b/src/ringme.js
@@ -112,10 +112,13 @@ var RingMe = new function() {
     anchor.className = this.buttonClass || 'btn btn--beta btn--icon sflicon-gauge ring--button btn--download';
     anchor.addEventListener('click', (
       function (event) {
-        _ringMeClickEventHandler.apply(
-          ringUIInstance,
-          [event]
-        );
+        if (!ringUIInstance.isRingSchemeSupported()) {
+          window.setTimeout(function() {
+            _ringMeClickEventHandler.apply(
+              ringUIInstance,
+              [event]);
+            }, 600);
+        }
       }
     ));
     anchor.appendChild(child);


### PR DESCRIPTION
### Changes proposed in this pull request:

 Waiting chrome timeout to call '_ringMeClickEventHandler' to avoid synchronization issue

### Status

- [X] READY
- [ ] HOLD
- [ ] WIP (Work-In-Progress)

### How to verify this change

- Click "Ring Me" after a first load.
- The download page redirect prompt WON'T appears. 

### Additional notes

The function isRingSchemeSupported runs asynchronous code to verify if the browser supports RingMe but does not wait for it to be completed. Therefore when the assertion if (this.ringUriSchemeSupported === URI_SCHEME_STATE.SUPPORTED) is checked, no callback was called yet to update the state of ringUriSchemeSupported.

I added a workaround using setTimeout to wait enough time before verifying the ringUriSchemeSupported state.